### PR TITLE
make http/https optional in ip

### DIFF
--- a/frisky
+++ b/frisky
@@ -34,7 +34,7 @@ signatures = [
   {
       "part": "contents",
       "type": "regex",
-      "pattern": "(url|host|host_?name|host_?addr|ip|ip_?addr|ip_?address)['\"]? ?[=:] ?['\"]((http|http)s?://)(1(?!(27|0|92)\\.)|[2-9]+)",
+      "pattern": "(url|host|host_?name|host_?addr|ip|ip_?addr|ip_?address)['\"]? ?[=:] ?['\"](((http|http)s?://)?)(1(?!(27|0|92)\\.)|[2-9]+)",
       "caption": "non RFC-1918 IP address",
       "description": None
   },


### PR DESCRIPTION
((http|http)s?://) should be optional since databases may not have http/https prefix
